### PR TITLE
fix for ffi string crash

### DIFF
--- a/src/tracking.rs
+++ b/src/tracking.rs
@@ -3,6 +3,8 @@ use openvr_sys::Enum_ETrackedPropertyError::*;
 
 use subsystems::*;
 use error::*;
+use std::slice;
+use std::str;
 
 /// Describes a string property of a tracked device
 #[derive(Debug, Copy, Clone)]
@@ -127,7 +129,10 @@ impl TrackedDevicePose {
             );
 
             if size > 0 {
-                return Ok(String::from_raw_parts(val_out.as_ptr() as *mut _, (size - 1) as usize, (size - 1) as usize));
+                let ptr = val_out.as_ptr() as *mut u8;
+                let mem = slice::from_raw_parts(ptr, size as usize);
+                let str = str::from_utf8(mem).unwrap();
+                return Ok(String::from(str));
             } else {
                 return Err(Error::from_raw(err));
             }


### PR DESCRIPTION
Using MSVC Rust 1.8 on Windows 10 + 8.1, opengl example crashes on String::from_raw_parts.
Replaced with string from slice::from_raw_parts.

May be platform difference due to this from Rust std::String documentation:
"The memory at ptr needs to have been previously allocated by the same allocator the standard library uses."