### PR TITLE
Update to 1.0.8

### DIFF
--- a/src/compositor/mod.rs
+++ b/src/compositor/mod.rs
@@ -136,6 +136,7 @@ pub mod compositor_error {
     pub const SHARED_TEXTURES_NOT_SUPPORTED: CompositorError = CompositorError(sys::EVRCompositorError_EVRCompositorError_VRCompositorError_SharedTexturesNotSupported);
     pub const INDEX_OUT_OF_RANGE: CompositorError = CompositorError(sys::EVRCompositorError_EVRCompositorError_VRCompositorError_IndexOutOfRange);
     pub const ALREADY_SUBMITTED: CompositorError = CompositorError(sys::EVRCompositorError_EVRCompositorError_VRCompositorError_AlreadySubmitted);
+    pub const INVALID_BOUNDS: CompositorError = CompositorError(sys::EVRCompositorError_EVRCompositorError_VRCompositorError_InvalidBounds);
 }
 
 impl fmt::Debug for CompositorError {
@@ -168,8 +169,3 @@ impl fmt::Display for CompositorError {
         f.pad(error::Error::description(self))
     }
 }
-
-pub use sys::VkPhysicalDevice_T;
-pub use sys::VkDevice_T;
-pub use sys::VkInstance_T;
-pub use sys::VkQueue_T;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,8 +8,8 @@ use openvr_sys as sys;
 
 mod tracking;
 
-mod system;
-mod compositor;
+pub mod system;
+pub mod compositor;
 
 pub use tracking::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,11 @@ mod compositor;
 
 pub use tracking::*;
 
+pub use sys::VkPhysicalDevice_T;
+pub use sys::VkDevice_T;
+pub use sys::VkInstance_T;
+pub use sys::VkQueue_T;
+
 static INITIALIZED: AtomicBool = ATOMIC_BOOL_INIT;
 
 /// Initialize OpenVR

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -152,6 +152,14 @@ impl<'a> System<'a> {
             _ => None,
         }
     }
+
+    pub fn vulkan_output_device(&self) -> Option<*mut VkPhysicalDevice_T> {
+        unsafe {
+            let mut device = mem::uninitialized();
+            self.0.GetOutputDevice.unwrap()(&mut device, sys::ETextureType_ETextureType_TextureType_Vulkan);
+            if device == 0 { None } else { Some(device as usize as *mut _) }
+        }
+    }
 }
 
 /// Values represent the tangents of the half-angles from the center view axis


### PR DESCRIPTION
This exposes a new method, fixes a safety hole (we call into foreign code that derefs a raw pointer), and exposes some modules I think we meant to be public.