### PR TITLE
Expose well known component names

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ description = "A safe binding for openvr."
 
 [dependencies]
 openvr_sys = { git = "https://github.com/Ralith/rust-openvr-sys.git", branch = "enum-rename" }
+lazy_static = "0.2.8"
 
 [dev_dependencies]
 glium = "0.14.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,6 @@
 extern crate openvr_sys;
+#[macro_use]
+extern crate lazy_static;
 
 use std::sync::atomic::{Ordering, AtomicBool, ATOMIC_BOOL_INIT};
 use std::{fmt, error, ptr, mem};

--- a/src/render_models.rs
+++ b/src/render_models.rs
@@ -259,3 +259,19 @@ pub mod component_properties {
     pub const IS_PRESSED: ComponentProperties = sys::EVRComponentProperty_VRComponentProperty_IsPressed;
     pub const IS_SCROLLED: ComponentProperties = sys::EVRComponentProperty_VRComponentProperty_IsScrolled;
 }
+
+pub mod component {
+    pub mod controller {
+        use std::ffi::CStr;
+        use openvr_sys as sys;
+
+        // TODO: Real constants
+        lazy_static! {
+            pub static ref GDC2015: &'static CStr = unsafe { CStr::from_bytes_with_nul_unchecked(sys::k_pch_Controller_Component_GDC2015) };
+            pub static ref BASE: &'static CStr = unsafe { CStr::from_bytes_with_nul_unchecked(sys::k_pch_Controller_Component_Base) };
+            pub static ref TIP: &'static CStr = unsafe { CStr::from_bytes_with_nul_unchecked(sys::k_pch_Controller_Component_Tip) };
+            pub static ref HAND_GRIP: &'static CStr = unsafe { CStr::from_bytes_with_nul_unchecked(sys::k_pch_Controller_Component_HandGrip) };
+            pub static ref STATUS: &'static CStr = unsafe { CStr::from_bytes_with_nul_unchecked(sys::k_pch_Controller_Component_Status) };
+        }
+    }
+}


### PR DESCRIPTION
I pulled in `lazy_static` for this in the interest of not forcing users to do the unsafe `CStr` conversion dance. Hopefully a future rust update will make the `CStr` constructors `const fn`s so we won't need to go to the extra effort any more.