### PR TITLE
State MIT license in manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
     "Rene Eichhorn",
     "Benjamin Saunders"
 ]
-license-file = "LICENSE.md"
+license = "MIT"
 
 homepage = "https://github.com/rust-openvr/rust-openvr"
 repository = "https://github.com/rust-openvr/rust-openvr"


### PR DESCRIPTION
Tools like [cargo manifest](https://github.com/onur/cargo-license) and badges get confused when they see "license-file" specified and assume that this crate has a "nonstandard license"

For example, [crates.io](https://crates.io/crates/openvr) states that the license is "non-standard".

According to the [manifest documentation](https://doc.rust-lang.org/cargo/reference/manifest.html):
~~~toml
# If a project is using a nonstandard license, then this key may be specified in
# lieu of the above key and must point to a file relative to this manifest
# (similar to the readme key).
license-file = "..."
~~~