### PR TITLE
bind the lifetimes of Compositor, System, Chaperone and RenderModels to the Context

### DIFF
--- a/src/chaperone.rs
+++ b/src/chaperone.rs
@@ -76,7 +76,7 @@ impl From<sys::ChaperoneCalibrationState> for ChaperoneCalibrationState {
     }
 }
 
-impl Chaperone {
+impl<'a> Chaperone<'a> {
     /// Get the current state of Chaperone calibration.
     /// This state can change at any time during a session due to physical base station changes.
     /// (NOTE: Some of these error codes are never returned as implementation for the error states

--- a/src/compositor/mod.rs
+++ b/src/compositor/mod.rs
@@ -19,7 +19,7 @@ pub use self::texture::Texture;
 
 use super::*;
 
-impl Compositor {
+impl<'a> Compositor<'a> {
     pub fn vulkan_instance_extensions_required(&self) -> Vec<CString> {
         let temp = unsafe {
             get_string(|ptr, n| self.0.GetVulkanInstanceExtensionsRequired.unwrap()(ptr, n))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,10 +57,10 @@ pub unsafe fn init(ty: ApplicationType) -> Result<Context, InitError> {
     })
 }
 
-pub struct System(&'static sys::VR_IVRSystem_FnTable);
-pub struct Compositor(&'static sys::VR_IVRCompositor_FnTable);
-pub struct RenderModels(&'static sys::VR_IVRRenderModels_FnTable);
-pub struct Chaperone(&'static sys::VR_IVRChaperone_FnTable);
+pub struct System<'a>(&'a sys::VR_IVRSystem_FnTable);
+pub struct Compositor<'a>(&'a sys::VR_IVRCompositor_FnTable);
+pub struct RenderModels<'a>(&'a sys::VR_IVRRenderModels_FnTable);
+pub struct Chaperone<'a>(&'a sys::VR_IVRChaperone_FnTable);
 
 /// Entry points into OpenVR.
 ///

--- a/src/render_models.rs
+++ b/src/render_models.rs
@@ -5,7 +5,7 @@ use openvr_sys as sys;
 
 use {get_string, ControllerState, RenderModels};
 
-impl RenderModels {
+impl<'a> RenderModels<'a> {
     /// Loads and returns a render model for use in the application. `name` should be a render model name from the
     /// `RenderModelName_String` property or an absolute path name to a render model on disk.
     ///

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -13,7 +13,7 @@ use super::*;
 
 pub use self::event::{Event, EventInfo};
 
-impl System {
+impl<'a> System<'a> {
     /// Provides the game with the minimum size that it should use for its offscreen render target to minimize pixel
     /// stretching. This size is matched with the projection matrix and distortion function and will change from display
     /// to display depending on resolution, distortion, and field of view.


### PR DESCRIPTION
this prevents issues like https://github.com/rust-openvr/rust-openvr/issues/42 by having the borrow checker make sure that the `Context` is kept around while derived objects are in use