### PR TITLE
Major idiomatic refactor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,3 @@ maintenance = { status = "passively-maintained" }
 [dependencies]
 openvr_sys = "2.0.3"
 lazy_static = "1.3.0"
-vk-sys = {version = "0.5", optional = true}
-
-[features]
-default = []
-vulkan = ["vk-sys"]  # Enables Vulkan interface functions.
-#d3d12 = []   # Enables D3D12 interface functions.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openvr"
-version = "0.6.0"
+version = "0.7.0"
 authors = [
     "Colin Sherratt",
     "Erick Tryzelaar",
@@ -24,3 +24,9 @@ maintenance = { status = "passively-maintained" }
 [dependencies]
 openvr_sys = "2.0.3"
 lazy_static = "1.3.0"
+vk-sys = {version = "0.5", optional = true}
+
+[features]
+default = []
+vulkan = ["vk-sys"]  # Enables Vulkan interface functions.
+#d3d12 = []   # Enables D3D12 interface functions.

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -53,7 +53,7 @@ fn main() {
     print!("\tPoses ");
     let poses = system
         .device_to_absolute_tracking_pose(openvr::TrackingUniverseOrigin::RawAndUncalibrated, 0.0);
-    for pose in poses.iter() {
+    for pose in poses.iter() { // FIXME: Clippy is yelling at this. Why is this a loop?
         print_matrix(8 + 6, pose.device_to_absolute_tracking());
         break;
     }

--- a/src/compositor/mod.rs
+++ b/src/compositor/mod.rs
@@ -35,13 +35,12 @@ impl Compositor {
     ///
     /// # Safety
     /// The specified physical device must be a valid `VkPhysicalDevice`.
-    #[cfg(feature = "vulkan")]
     pub unsafe fn vulkan_device_extensions_required(
         &self,
-        physical_device: vk_sys::PhysicalDevice,
+        physical_device: interop::vulkan::PhysicalDevice,
     ) -> Vec<CString> {
         let temp = get_string(|ptr, n| {
-            self.0.GetVulkanDeviceExtensionsRequired.unwrap()(physical_device as *mut _, ptr, n)
+            self.0.GetVulkanDeviceExtensionsRequired.unwrap()(physical_device as _, ptr, n)
         })
         .unwrap();
         temp.as_bytes()
@@ -81,7 +80,6 @@ impl Compositor {
     /// If `bounds` is None, the entire texture will be used. Lens distortion is handled by the OpenVR implementation.
     ///
     /// # Safety
-    ///
     /// The handles you supply must be valid and comply with the graphics API's synchronization requirements.
     pub unsafe fn submit(
         &self,
@@ -92,7 +90,6 @@ impl Compositor {
     ) -> Result<(), CompositorError> {
         use self::texture::Handle::*;
         let flags = match texture.handle {
-            #[cfg(feature = "vulkan")]
             Vulkan(_) => sys::EVRSubmitFlags_Submit_Default,
             OpenGLTexture(_) => sys::EVRSubmitFlags_Submit_Default,
             OpenGLRenderBuffer(_) => sys::EVRSubmitFlags_Submit_GlRenderBuffer,
@@ -103,13 +100,11 @@ impl Compositor {
         };
         let texture = sys::VRTextureWithPose_t_real {
             handle: match texture.handle {
-                #[cfg(feature = "vulkan")]
                 Vulkan(ref x) => x as *const _ as *mut _,
                 OpenGLTexture(x) => x as *mut _,
                 OpenGLRenderBuffer(x) => x as *mut _,
             },
             eType: match texture.handle {
-                #[cfg(feature = "vulkan")]
                 Vulkan(_) => sys::ETextureType_TextureType_Vulkan,
                 OpenGLTexture(_) => sys::ETextureType_TextureType_OpenGL,
                 OpenGLRenderBuffer(_) => sys::ETextureType_TextureType_OpenGL,

--- a/src/compositor/texture.rs
+++ b/src/compositor/texture.rs
@@ -1,4 +1,4 @@
-use super::sys;
+use crate::{sys, interop};
 
 #[derive(Debug, Copy, Clone)]
 pub struct Texture {
@@ -12,32 +12,10 @@ pub struct Bounds {
     pub max: (f32, f32),
 }
 
-/// Support types specifically for interactions between the compositor and Vulkan.
-#[cfg(feature = "vulkan")]
-pub mod vulkan {
-    #[repr(C)]
-    #[derive(Debug, Copy, Clone)]
-    pub struct Texture {
-        pub image: u64,
-        pub device: vk_sys::Device,
-        pub physical_device: vk_sys::PhysicalDevice,
-        pub instance: vk_sys::Instance,
-        pub queue: vk_sys::Queue,
-        pub queue_family_index: u32,
-        pub width: u32,
-        pub height: u32,
-        pub format: u32,
-        pub sample_count: u32,
-    }
-    // These two are no longer needed
-    //unsafe impl Send for Texture {}
-    //unsafe impl Sync for Texture {}
-}
 
 #[derive(Debug, Copy, Clone)]
 pub enum Handle {
-    #[cfg(feature = "vulkan")]
-    Vulkan(vulkan::Texture),
+    Vulkan(interop::vulkan::Texture),
     OpenGLTexture(usize),
     OpenGLRenderBuffer(usize),
 }

--- a/src/compositor/texture.rs
+++ b/src/compositor/texture.rs
@@ -1,4 +1,4 @@
-use super::{sys, VkDevice_T, VkInstance_T, VkPhysicalDevice_T, VkQueue_T};
+use super::sys;
 
 #[derive(Debug, Copy, Clone)]
 pub struct Texture {
@@ -12,28 +12,31 @@ pub struct Bounds {
     pub max: (f32, f32),
 }
 
+/// Support types specifically for interactions between the compositor and Vulkan.
+#[cfg(feature = "vulkan")]
 pub mod vulkan {
-    use super::*;
     #[repr(C)]
     #[derive(Debug, Copy, Clone)]
     pub struct Texture {
         pub image: u64,
-        pub device: *mut VkDevice_T,
-        pub physical_device: *mut VkPhysicalDevice_T,
-        pub instance: *mut VkInstance_T,
-        pub queue: *mut VkQueue_T,
+        pub device: vk_sys::Device,
+        pub physical_device: vk_sys::PhysicalDevice,
+        pub instance: vk_sys::Instance,
+        pub queue: vk_sys::Queue,
         pub queue_family_index: u32,
         pub width: u32,
         pub height: u32,
         pub format: u32,
         pub sample_count: u32,
     }
-    unsafe impl Send for Texture{}
-    unsafe impl Sync for Texture{}
+    // These two are no longer needed
+    //unsafe impl Send for Texture {}
+    //unsafe impl Sync for Texture {}
 }
 
 #[derive(Debug, Copy, Clone)]
 pub enum Handle {
+    #[cfg(feature = "vulkan")]
     Vulkan(vulkan::Texture),
     OpenGLTexture(usize),
     OpenGLRenderBuffer(usize),

--- a/src/interop/mod.rs
+++ b/src/interop/mod.rs
@@ -1,0 +1,4 @@
+//! Types required for interoperating with graphics APIs supported by OpenVR.
+//!
+//! See the individual submodules depending on the API you're using.
+pub mod vulkan;

--- a/src/interop/vulkan.rs
+++ b/src/interop/vulkan.rs
@@ -1,0 +1,43 @@
+//! Types used for interoperation between OpenVR and Vulkan.
+
+/// A Vulkan object handle. The object type behind it is unspecified.
+pub type Handle = *const ();
+
+/// Handle to a Vulkan instance.
+///
+/// Consult the Vulkan documentation on what this exactly is.
+pub type Instance = Handle;
+/// Handle to a Vulkan device.
+///
+/// Consult the Vulkan documentation on what this exactly is.
+pub type Device = Handle;
+/// Handle to a Vulkan physical device.
+///
+/// Consult the Vulkan documentation on what this exactly is.
+pub type PhysicalDevice = Handle;
+
+/// Handle to a Vulkan queue.
+///
+/// Consult the Vulkan documentation on what this exactly is.
+pub type Queue = Handle;
+
+/// Description of a texture, used by the compositor.
+///
+/// You need to fill out this structure yourself according to the parameters of the texture you want to use, thus all functions which rely on the contents are unsafe.
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct Texture {
+    pub image: u64,
+    pub device: Device,
+    pub physical_device: PhysicalDevice,
+    pub instance: Instance,
+    pub queue: Queue,
+    pub queue_family_index: u32,
+    pub width: u32,
+    pub height: u32,
+    pub format: u32,
+    pub sample_count: u32,
+}
+// These two are no longer needed
+//unsafe impl Send for Texture {}
+//unsafe impl Sync for Texture {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,6 @@
 extern crate openvr_sys;
 #[macro_use]
 extern crate lazy_static;
-#[cfg(feature = "vulkan")]
-extern crate vk_sys;
 
 use std::cell::Cell;
 use std::ffi::{CStr, CString};
@@ -18,6 +16,7 @@ pub mod compositor;
 pub mod property;
 pub mod render_models;
 pub mod system;
+pub mod interop;
 
 pub use tracking::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 extern crate openvr_sys;
 #[macro_use]
 extern crate lazy_static;
+#[cfg(feature = "vulkan")]
+extern crate vk_sys;
 
 use std::cell::Cell;
 use std::ffi::{CStr, CString};
@@ -18,11 +20,6 @@ pub mod render_models;
 pub mod system;
 
 pub use tracking::*;
-
-pub use sys::VkDevice_T;
-pub use sys::VkInstance_T;
-pub use sys::VkPhysicalDevice_T;
-pub use sys::VkQueue_T;
 
 static INITIALIZED: AtomicBool = AtomicBool::new(false);
 
@@ -112,7 +109,7 @@ impl Context {
     /// attempting to free graphics resources.
     ///
     /// No calls to other OpenVR methods may be made after this has been called unless a new `Context` is first
-   
+
     /// constructed.
     pub unsafe fn shutdown(&self) {
         if self.live.swap(false, Ordering::Acquire) {

--- a/src/property.rs
+++ b/src/property.rs
@@ -1,234 +1,400 @@
-#![allow(non_upper_case_globals)]
+//! Tracked device property handling.
+//!
+//! This module provides a comprehensive list of all known tracked device properties. Use the `TrackingDevice`'s `get_property` method to use this in a convenient and readable way.
 
-use super::TrackedDeviceProperty;
 use openvr_sys as sys;
+use super::{tracking::TrackedDevice, get_string};
+use std::{fmt, mem};
 
-pub const Invalid: TrackedDeviceProperty = sys::ETrackedDeviceProperty_Prop_Invalid;
-pub const TrackingSystemName_String: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_TrackingSystemName_String;
-pub const ModelNumber_String: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_ModelNumber_String;
-pub const SerialNumber_String: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_SerialNumber_String;
-pub const RenderModelName_String: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_RenderModelName_String;
-pub const WillDriftInYaw_Bool: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_WillDriftInYaw_Bool;
-pub const ManufacturerName_String: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_ManufacturerName_String;
-pub const TrackingFirmwareVersion_String: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_TrackingFirmwareVersion_String;
-pub const HardwareRevision_String: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_HardwareRevision_String;
-pub const AllWirelessDongleDescriptions_String: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_AllWirelessDongleDescriptions_String;
-pub const ConnectedWirelessDongle_String: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_ConnectedWirelessDongle_String;
-pub const DeviceIsWireless_Bool: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_DeviceIsWireless_Bool;
-pub const DeviceIsCharging_Bool: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_DeviceIsCharging_Bool;
-pub const DeviceBatteryPercentage_Float: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_DeviceBatteryPercentage_Float;
-pub const StatusDisplayTransform_Matrix34: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_StatusDisplayTransform_Matrix34;
-pub const Firmware_UpdateAvailable_Bool: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_Firmware_UpdateAvailable_Bool;
-pub const Firmware_ManualUpdate_Bool: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_Firmware_ManualUpdate_Bool;
-pub const Firmware_ManualUpdateURL_String: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_Firmware_ManualUpdateURL_String;
-pub const HardwareRevision_Uint64: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_HardwareRevision_Uint64;
-pub const FirmwareVersion_Uint64: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_FirmwareVersion_Uint64;
-pub const FPGAVersion_Uint64: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_FPGAVersion_Uint64;
-pub const VRCVersion_Uint64: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_VRCVersion_Uint64;
-pub const RadioVersion_Uint64: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_RadioVersion_Uint64;
-pub const DongleVersion_Uint64: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_DongleVersion_Uint64;
-pub const BlockServerShutdown_Bool: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_BlockServerShutdown_Bool;
-pub const CanUnifyCoordinateSystemWithHmd_Bool: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_CanUnifyCoordinateSystemWithHmd_Bool;
-pub const ContainsProximitySensor_Bool: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_ContainsProximitySensor_Bool;
-pub const DeviceProvidesBatteryStatus_Bool: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_DeviceProvidesBatteryStatus_Bool;
-pub const DeviceCanPowerOff_Bool: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_DeviceCanPowerOff_Bool;
-pub const Firmware_ProgrammingTarget_String: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_Firmware_ProgrammingTarget_String;
-pub const DeviceClass_Int32: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_DeviceClass_Int32;
-pub const HasCamera_Bool: TrackedDeviceProperty = sys::ETrackedDeviceProperty_Prop_HasCamera_Bool;
-pub const DriverVersion_String: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_DriverVersion_String;
-pub const Firmware_ForceUpdateRequired_Bool: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_Firmware_ForceUpdateRequired_Bool;
-pub const ViveSystemButtonFixRequired_Bool: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_ViveSystemButtonFixRequired_Bool;
-pub const ParentDriver_Uint64: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_ParentDriver_Uint64;
-pub const ResourceRoot_String: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_ResourceRoot_String;
-pub const ReportsTimeSinceVSync_Bool: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_ReportsTimeSinceVSync_Bool;
-pub const SecondsFromVsyncToPhotons_Float: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_SecondsFromVsyncToPhotons_Float;
-pub const DisplayFrequency_Float: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_DisplayFrequency_Float;
-pub const UserIpdMeters_Float: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_UserIpdMeters_Float;
-pub const CurrentUniverseId_Uint64: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_CurrentUniverseId_Uint64;
-pub const PreviousUniverseId_Uint64: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_PreviousUniverseId_Uint64;
-pub const DisplayFirmwareVersion_Uint64: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_DisplayFirmwareVersion_Uint64;
-pub const IsOnDesktop_Bool: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_IsOnDesktop_Bool;
-pub const DisplayMCType_Int32: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_DisplayMCType_Int32;
-pub const DisplayMCOffset_Float: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_DisplayMCOffset_Float;
-pub const DisplayMCScale_Float: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_DisplayMCScale_Float;
-pub const EdidVendorID_Int32: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_EdidVendorID_Int32;
-pub const DisplayMCImageLeft_String: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_DisplayMCImageLeft_String;
-pub const DisplayMCImageRight_String: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_DisplayMCImageRight_String;
-pub const DisplayGCBlackClamp_Float: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_DisplayGCBlackClamp_Float;
-pub const EdidProductID_Int32: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_EdidProductID_Int32;
-pub const CameraToHeadTransform_Matrix34: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_CameraToHeadTransform_Matrix34;
-pub const DisplayGCType_Int32: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_DisplayGCType_Int32;
-pub const DisplayGCOffset_Float: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_DisplayGCOffset_Float;
-pub const DisplayGCScale_Float: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_DisplayGCScale_Float;
-pub const DisplayGCPrescale_Float: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_DisplayGCPrescale_Float;
-pub const DisplayGCImage_String: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_DisplayGCImage_String;
-pub const LensCenterLeftU_Float: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_LensCenterLeftU_Float;
-pub const LensCenterLeftV_Float: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_LensCenterLeftV_Float;
-pub const LensCenterRightU_Float: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_LensCenterRightU_Float;
-pub const LensCenterRightV_Float: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_LensCenterRightV_Float;
-pub const UserHeadToEyeDepthMeters_Float: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_UserHeadToEyeDepthMeters_Float;
-pub const CameraFirmwareVersion_Uint64: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_CameraFirmwareVersion_Uint64;
-pub const CameraFirmwareDescription_String: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_CameraFirmwareDescription_String;
-pub const DisplayFPGAVersion_Uint64: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_DisplayFPGAVersion_Uint64;
-pub const DisplayBootloaderVersion_Uint64: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_DisplayBootloaderVersion_Uint64;
-pub const DisplayHardwareVersion_Uint64: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_DisplayHardwareVersion_Uint64;
-pub const AudioFirmwareVersion_Uint64: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_AudioFirmwareVersion_Uint64;
-pub const CameraCompatibilityMode_Int32: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_CameraCompatibilityMode_Int32;
-pub const ScreenshotHorizontalFieldOfViewDegrees_Float: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_ScreenshotHorizontalFieldOfViewDegrees_Float;
-pub const ScreenshotVerticalFieldOfViewDegrees_Float: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_ScreenshotVerticalFieldOfViewDegrees_Float;
-pub const DisplaySuppressed_Bool: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_DisplaySuppressed_Bool;
-pub const DisplayAllowNightMode_Bool: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_DisplayAllowNightMode_Bool;
-pub const DisplayMCImageWidth_Int32: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_DisplayMCImageWidth_Int32;
-pub const DisplayMCImageHeight_Int32: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_DisplayMCImageHeight_Int32;
-pub const DisplayMCImageNumChannels_Int32: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_DisplayMCImageNumChannels_Int32;
-pub const DisplayMCImageData_Binary: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_DisplayMCImageData_Binary;
-pub const SecondsFromPhotonsToVblank_Float: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_SecondsFromPhotonsToVblank_Float;
-pub const DriverDirectModeSendsVsyncEvents_Bool: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_DriverDirectModeSendsVsyncEvents_Bool;
-pub const DisplayDebugMode_Bool: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_DisplayDebugMode_Bool;
-pub const GraphicsAdapterLuid_Uint64: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_GraphicsAdapterLuid_Uint64;
-pub const AttachedDeviceId_String: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_AttachedDeviceId_String;
-pub const SupportedButtons_Uint64: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_SupportedButtons_Uint64;
-pub const Axis0Type_Int32: TrackedDeviceProperty = sys::ETrackedDeviceProperty_Prop_Axis0Type_Int32;
-pub const Axis1Type_Int32: TrackedDeviceProperty = sys::ETrackedDeviceProperty_Prop_Axis1Type_Int32;
-pub const Axis2Type_Int32: TrackedDeviceProperty = sys::ETrackedDeviceProperty_Prop_Axis2Type_Int32;
-pub const Axis3Type_Int32: TrackedDeviceProperty = sys::ETrackedDeviceProperty_Prop_Axis3Type_Int32;
-pub const Axis4Type_Int32: TrackedDeviceProperty = sys::ETrackedDeviceProperty_Prop_Axis4Type_Int32;
-pub const ControllerRoleHint_Int32: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_ControllerRoleHint_Int32;
-pub const FieldOfViewLeftDegrees_Float: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_FieldOfViewLeftDegrees_Float;
-pub const FieldOfViewRightDegrees_Float: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_FieldOfViewRightDegrees_Float;
-pub const FieldOfViewTopDegrees_Float: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_FieldOfViewTopDegrees_Float;
-pub const FieldOfViewBottomDegrees_Float: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_FieldOfViewBottomDegrees_Float;
-pub const TrackingRangeMinimumMeters_Float: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_TrackingRangeMinimumMeters_Float;
-pub const TrackingRangeMaximumMeters_Float: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_TrackingRangeMaximumMeters_Float;
-pub const ModeLabel_String: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_ModeLabel_String;
-pub const IconPathName_String: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_IconPathName_String;
-pub const NamedIconPathDeviceOff_String: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_NamedIconPathDeviceOff_String;
-pub const NamedIconPathDeviceSearching_String: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_NamedIconPathDeviceSearching_String;
-pub const NamedIconPathDeviceSearchingAlert_String: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_NamedIconPathDeviceSearchingAlert_String;
-pub const NamedIconPathDeviceReady_String: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_NamedIconPathDeviceReady_String;
-pub const NamedIconPathDeviceReadyAlert_String: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_NamedIconPathDeviceReadyAlert_String;
-pub const NamedIconPathDeviceNotReady_String: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_NamedIconPathDeviceNotReady_String;
-pub const NamedIconPathDeviceStandby_String: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_NamedIconPathDeviceStandby_String;
-pub const NamedIconPathDeviceAlertLow_String: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_NamedIconPathDeviceAlertLow_String;
-pub const DisplayHiddenArea_Binary_Start: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_DisplayHiddenArea_Binary_Start;
-pub const DisplayHiddenArea_Binary_End: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_DisplayHiddenArea_Binary_End;
-pub const UserConfigPath_String: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_UserConfigPath_String;
-pub const InstallPath_String: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_InstallPath_String;
-pub const HasDisplayComponent_Bool: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_HasDisplayComponent_Bool;
-pub const HasControllerComponent_Bool: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_HasControllerComponent_Bool;
-pub const HasCameraComponent_Bool: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_HasCameraComponent_Bool;
-pub const HasDriverDirectModeComponent_Bool: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_HasDriverDirectModeComponent_Bool;
-pub const HasVirtualDisplayComponent_Bool: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_HasVirtualDisplayComponent_Bool;
-pub const VendorSpecific_Reserved_Start: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_VendorSpecific_Reserved_Start;
-pub const VendorSpecific_Reserved_End: TrackedDeviceProperty =
-    sys::ETrackedDeviceProperty_Prop_VendorSpecific_Reserved_End;
+/// The properties of a tracked device.
+// TODO: Add documentation for each of these properties. Right now they only have type info.
+// TODO: Add support for array properties. These should not be handled as usual properties: we need a separate enum an a separate set of methods for that.
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Property {
+    /// Will always fail when querying, and thus does not have a type.
+    Invalid = sys::ETrackedDeviceProperty_Prop_Invalid,
+    /// *Type: `String`*
+    TrackingSystemName = sys::ETrackedDeviceProperty_Prop_TrackingSystemName_String,
+    /// *Type: `String`*
+    ModelNumber = sys::ETrackedDeviceProperty_Prop_ModelNumber_String,
+    /// *Type: `String`*
+    SerialNumber = sys::ETrackedDeviceProperty_Prop_SerialNumber_String,
+    /// *Type: `String`*
+    RenderModelName = sys::ETrackedDeviceProperty_Prop_RenderModelName_String,
+    /// *Type: `bool`*
+    WillDriftInYaw = sys::ETrackedDeviceProperty_Prop_WillDriftInYaw_Bool,
+    /// *Type: `String`*
+    ManufacturerName = sys::ETrackedDeviceProperty_Prop_ManufacturerName_String,
+    /// *Type: `String`*
+    TrackingFirmwareVersion = sys::ETrackedDeviceProperty_Prop_TrackingFirmwareVersion_String,
+    /// *Type: `String`*
+    HardwareRevision = sys::ETrackedDeviceProperty_Prop_HardwareRevision_String,
+    /// *Type: `String`*
+    AllWirelessDongleDescriptions = sys::ETrackedDeviceProperty_Prop_AllWirelessDongleDescriptions_String,
+    /// *Type: `String`*
+    ConnectedWirelessDongle = sys::ETrackedDeviceProperty_Prop_ConnectedWirelessDongle_String,
+    /// *Type: `bool`*
+    DeviceIsWireless = sys::ETrackedDeviceProperty_Prop_DeviceIsWireless_Bool,
+    /// *Type: `bool`*
+    DeviceIsCharging = sys::ETrackedDeviceProperty_Prop_DeviceIsCharging_Bool,
+    /// *Type: `f32`*
+    DeviceBatteryPercentage = sys::ETrackedDeviceProperty_Prop_DeviceBatteryPercentage_Float,
+    /// *Type: 3x4 matrix ([`Matrix34`][m34])*
+    ///
+    /// [m34]: type.Matrix34.html "Matrix34 — a 3x4 matrix, as a tracked device property value"
+    StatusDisplayTransform = sys::ETrackedDeviceProperty_Prop_StatusDisplayTransform_Matrix34,
+    /// *Type: `bool`*
+    FirmwareUpdateAvailable = sys::ETrackedDeviceProperty_Prop_Firmware_UpdateAvailable_Bool,
+    /// *Type: `bool`*
+    FirmwareManualUpdate = sys::ETrackedDeviceProperty_Prop_Firmware_ManualUpdate_Bool,
+    /// *Type: `String`*
+    FirmwareManualUpdateURL = sys::ETrackedDeviceProperty_Prop_Firmware_ManualUpdateURL_String,
+    /// *Type: `u64`*
+    HardwareRevisionNumber = sys::ETrackedDeviceProperty_Prop_HardwareRevision_Uint64,
+    /// *Type: `u64`*
+    FirmwareVersion = sys::ETrackedDeviceProperty_Prop_FirmwareVersion_Uint64,
+    /// *Type: `u64`*
+    FPGAVersion = sys::ETrackedDeviceProperty_Prop_FPGAVersion_Uint64,
+    /// *Type: `u64`*
+    VRCVersion = sys::ETrackedDeviceProperty_Prop_VRCVersion_Uint64,
+    /// *Type: `u64`*
+    RadioVersion = sys::ETrackedDeviceProperty_Prop_RadioVersion_Uint64,
+    /// *Type: `u64`*
+    DongleVersion = sys::ETrackedDeviceProperty_Prop_DongleVersion_Uint64,
+    /// *Type: `bool`*
+    BlockServerShutdown = sys::ETrackedDeviceProperty_Prop_BlockServerShutdown_Bool,
+    /// *Type: `bool`*
+    CanUnifyCoordinateSystemWithHmd = sys::ETrackedDeviceProperty_Prop_CanUnifyCoordinateSystemWithHmd_Bool,
+    /// *Type: `bool`*
+    ContainsProximitySensor = sys::ETrackedDeviceProperty_Prop_ContainsProximitySensor_Bool,
+    /// *Type: `bool`*
+    DeviceProvidesBatteryStatus = sys::ETrackedDeviceProperty_Prop_DeviceProvidesBatteryStatus_Bool,
+    /// *Type: `bool`*
+    DeviceCanPowerOff = sys::ETrackedDeviceProperty_Prop_DeviceCanPowerOff_Bool,
+    /// *Type: `String`*
+    FirmwareProgrammingTarget = sys::ETrackedDeviceProperty_Prop_Firmware_ProgrammingTarget_String,
+    /// *Type: `i32`*
+    DeviceClass = sys::ETrackedDeviceProperty_Prop_DeviceClass_Int32,
+    /// *Type: `bool`*
+    HasCamera = sys::ETrackedDeviceProperty_Prop_HasCamera_Bool,
+    DriverVersion = sys::ETrackedDeviceProperty_Prop_DriverVersion_String,
+    /// *Type: `bool`*
+    FirmwareForceUpdateRequired = sys::ETrackedDeviceProperty_Prop_Firmware_ForceUpdateRequired_Bool,
+    /// *Type: `bool`*
+    ViveSystemButtonFixRequired = sys::ETrackedDeviceProperty_Prop_ViveSystemButtonFixRequired_Bool,
+    ParentDriver = sys::ETrackedDeviceProperty_Prop_ParentDriver_Uint64,
+    /// *Type: `String`*
+    ResourceRoot = sys::ETrackedDeviceProperty_Prop_ResourceRoot_String,
+    /// *Type: `bool`*
+    ReportsTimeSinceVSync = sys::ETrackedDeviceProperty_Prop_ReportsTimeSinceVSync_Bool,
+    /// *Type: `f32`*
+    SecondsFromVsyncToPhotons = sys::ETrackedDeviceProperty_Prop_SecondsFromVsyncToPhotons_Float,
+    /// *Type: `f32`*
+    DisplayFrequency = sys::ETrackedDeviceProperty_Prop_DisplayFrequency_Float,
+    /// *Type: `f32`*
+    UserIpdMeters = sys::ETrackedDeviceProperty_Prop_UserIpdMeters_Float,
+    /// *Type: `u64`*
+    CurrentUniverseId = sys::ETrackedDeviceProperty_Prop_CurrentUniverseId_Uint64,
+    /// *Type: `u64`*
+    PreviousUniverseId = sys::ETrackedDeviceProperty_Prop_PreviousUniverseId_Uint64,
+    /// *Type: `u64`*
+    DisplayFirmwareVersion = sys::ETrackedDeviceProperty_Prop_DisplayFirmwareVersion_Uint64,
+    /// *Type: `bool`*
+    IsOnDesktop = sys::ETrackedDeviceProperty_Prop_IsOnDesktop_Bool,
+    /// *Type: `i32`*
+    DisplayMCType = sys::ETrackedDeviceProperty_Prop_DisplayMCType_Int32,
+    /// *Type: `f32`*
+    DisplayMCOffset = sys::ETrackedDeviceProperty_Prop_DisplayMCOffset_Float,
+    /// *Type: `f32`*
+    DisplayMCScale = sys::ETrackedDeviceProperty_Prop_DisplayMCScale_Float,
+    /// *Type: `i32`*
+    EdidVendorID = sys::ETrackedDeviceProperty_Prop_EdidVendorID_Int32,
+    /// *Type: `String`*
+    DisplayMCImageLeft = sys::ETrackedDeviceProperty_Prop_DisplayMCImageLeft_String,
+    /// *Type: `String`*
+    DisplayMCImageRight = sys::ETrackedDeviceProperty_Prop_DisplayMCImageRight_String,
+    DisplayGCBlackClamp = sys::ETrackedDeviceProperty_Prop_DisplayGCBlackClamp_Float,
+    EdidProductID = sys::ETrackedDeviceProperty_Prop_EdidProductID_Int32,
+    /// *Type: 3x4 matrix ([`Matrix34`][m34])*
+    ///
+    /// [m34]: type.Matrix34.html "Matrix34 — a 3x4 matrix, as a tracked device property value"
+    CameraToHeadTransform = sys::ETrackedDeviceProperty_Prop_CameraToHeadTransform_Matrix34,
+    DisplayGCType = sys::ETrackedDeviceProperty_Prop_DisplayGCType_Int32,
+    /// *Type: `f32`*
+    DisplayGCOffset = sys::ETrackedDeviceProperty_Prop_DisplayGCOffset_Float,
+    /// *Type: `f32`*
+    DisplayGCScale = sys::ETrackedDeviceProperty_Prop_DisplayGCScale_Float,
+    /// *Type: `f32`*
+    DisplayGCPrescale = sys::ETrackedDeviceProperty_Prop_DisplayGCPrescale_Float,
+    DisplayGCImage = sys::ETrackedDeviceProperty_Prop_DisplayGCImage_String,
+    /// *Type: `f32`*
+    LensCenterLeftU = sys::ETrackedDeviceProperty_Prop_LensCenterLeftU_Float,
+    /// *Type: `f32`*
+    LensCenterLeftV = sys::ETrackedDeviceProperty_Prop_LensCenterLeftV_Float,
+    /// *Type: `f32`*
+    LensCenterRightU = sys::ETrackedDeviceProperty_Prop_LensCenterRightU_Float,
+    /// *Type: `f32`*
+    LensCenterRightV = sys::ETrackedDeviceProperty_Prop_LensCenterRightV_Float,
+    /// *Type: `f32`*
+    UserHeadToEyeDepthMeters = sys::ETrackedDeviceProperty_Prop_UserHeadToEyeDepthMeters_Float,
+    /// *Type: `u64`*
+    CameraFirmwareVersion = sys::ETrackedDeviceProperty_Prop_CameraFirmwareVersion_Uint64,
+    /// *Type: `String`*
+    CameraFirmwareDescription = sys::ETrackedDeviceProperty_Prop_CameraFirmwareDescription_String,
+    /// *Type: `u64`*
+    DisplayFPGAVersion = sys::ETrackedDeviceProperty_Prop_DisplayFPGAVersion_Uint64,
+    /// *Type: `u64`*
+    DisplayBootloaderVersion = sys::ETrackedDeviceProperty_Prop_DisplayBootloaderVersion_Uint64,
+    /// *Type: `u64`*
+    DisplayHardwareVersion = sys::ETrackedDeviceProperty_Prop_DisplayHardwareVersion_Uint64,
+    /// *Type: `u64`*
+    AudioFirmwareVersion = sys::ETrackedDeviceProperty_Prop_AudioFirmwareVersion_Uint64,
+    /// *Type: `i32`*
+    CameraCompatibilityMode = sys::ETrackedDeviceProperty_Prop_CameraCompatibilityMode_Int32,
+    /// *Type: `f32`*
+    ScreenshotHorizontalFieldOfViewDegrees = sys::ETrackedDeviceProperty_Prop_ScreenshotHorizontalFieldOfViewDegrees_Float,
+    /// *Type: `f32`*
+    ScreenshotVerticalFieldOfViewDegrees = sys::ETrackedDeviceProperty_Prop_ScreenshotVerticalFieldOfViewDegrees_Float,
+    /// *Type: `bool`*
+    DisplaySuppressed = sys::ETrackedDeviceProperty_Prop_DisplaySuppressed_Bool,
+    /// *Type: `bool`*
+    DisplayAllowNightMode = sys::ETrackedDeviceProperty_Prop_DisplayAllowNightMode_Bool,
+    /// *Type: `i32`*
+    DisplayMCImageWidth = sys::ETrackedDeviceProperty_Prop_DisplayMCImageWidth_Int32,
+    /// *Type: `i32`*
+    DisplayMCImageHeight = sys::ETrackedDeviceProperty_Prop_DisplayMCImageHeight_Int32,
+    /// *Type: `i32`*
+    DisplayMCImageNumChannels = sys::ETrackedDeviceProperty_Prop_DisplayMCImageNumChannels_Int32,
+    // FIXME: No idea what to do here.
+    //DisplayMCImageData_Binary = sys::ETrackedDeviceProperty_Prop_DisplayMCImageData_Binary,
+    /// *Type: `f32`*
+    SecondsFromPhotonsToVblank = sys::ETrackedDeviceProperty_Prop_SecondsFromPhotonsToVblank_Float,
+    /// *Type: `bool`*
+    DriverDirectModeSendsVsyncEvents = sys::ETrackedDeviceProperty_Prop_DriverDirectModeSendsVsyncEvents_Bool,
+    /// *Type: `bool`*
+    DisplayDebugMode = sys::ETrackedDeviceProperty_Prop_DisplayDebugMode_Bool,
+    /// *Type: `u64`*
+    GraphicsAdapterLuid = sys::ETrackedDeviceProperty_Prop_GraphicsAdapterLuid_Uint64,
+    /// *Type: `String`*
+    AttachedDeviceId = sys::ETrackedDeviceProperty_Prop_AttachedDeviceId_String,
+    /// *Type: `u64`*
+    SupportedButtons = sys::ETrackedDeviceProperty_Prop_SupportedButtons_Uint64,
+    /// *Type: `i32`*
+    Axis0Type = sys::ETrackedDeviceProperty_Prop_Axis0Type_Int32,
+    /// *Type: `i32`*
+    Axis1Type = sys::ETrackedDeviceProperty_Prop_Axis1Type_Int32,
+    /// *Type: `i32`*
+    Axis2Type = sys::ETrackedDeviceProperty_Prop_Axis2Type_Int32,
+    /// *Type: `i32`*
+    Axis3Type = sys::ETrackedDeviceProperty_Prop_Axis3Type_Int32,
+    /// *Type: `i32`*
+    Axis4Type = sys::ETrackedDeviceProperty_Prop_Axis4Type_Int32,
+    ControllerRoleHint = sys::ETrackedDeviceProperty_Prop_ControllerRoleHint_Int32,
+    /// *Type: `f32`*
+    FieldOfViewLeftDegrees = sys::ETrackedDeviceProperty_Prop_FieldOfViewLeftDegrees_Float,
+    /// *Type: `f32`*
+    FieldOfViewRightDegrees = sys::ETrackedDeviceProperty_Prop_FieldOfViewRightDegrees_Float,
+    /// *Type: `f32`*
+    FieldOfViewTopDegrees = sys::ETrackedDeviceProperty_Prop_FieldOfViewTopDegrees_Float,
+    /// *Type: `f32`*
+    FieldOfViewBottomDegrees = sys::ETrackedDeviceProperty_Prop_FieldOfViewBottomDegrees_Float,
+    /// *Type: `f32`*
+    TrackingRangeMinimumMeters = sys::ETrackedDeviceProperty_Prop_TrackingRangeMinimumMeters_Float,
+    /// *Type: `f32`*
+    TrackingRangeMaximumMeters = sys::ETrackedDeviceProperty_Prop_TrackingRangeMaximumMeters_Float,
+    /// *Type: `String`*
+    ModeLabel = sys::ETrackedDeviceProperty_Prop_ModeLabel_String,
+    /// *Type: `String`*
+    IconPathName = sys::ETrackedDeviceProperty_Prop_IconPathName_String,
+    /// *Type: `String`*
+    NamedIconPathDeviceOff = sys::ETrackedDeviceProperty_Prop_NamedIconPathDeviceOff_String,
+    /// *Type: `String`*
+    NamedIconPathDeviceSearching = sys::ETrackedDeviceProperty_Prop_NamedIconPathDeviceSearching_String,
+    /// *Type: `String`*
+    NamedIconPathDeviceSearchingAlert = sys::ETrackedDeviceProperty_Prop_NamedIconPathDeviceSearchingAlert_String,
+    /// *Type: `String`*
+    NamedIconPathDeviceReady = sys::ETrackedDeviceProperty_Prop_NamedIconPathDeviceReady_String,
+    /// *Type: `String`*
+    NamedIconPathDeviceReadyAlert = sys::ETrackedDeviceProperty_Prop_NamedIconPathDeviceReadyAlert_String,
+    /// *Type: `String`*
+    NamedIconPathDeviceNotReady = sys::ETrackedDeviceProperty_Prop_NamedIconPathDeviceNotReady_String,
+    /// *Type: `String`*
+    NamedIconPathDeviceStandby = sys::ETrackedDeviceProperty_Prop_NamedIconPathDeviceStandby_String,
+    /// *Type: `String`*
+    NamedIconPathDeviceAlertLow = sys::ETrackedDeviceProperty_Prop_NamedIconPathDeviceAlertLow_String,
+    /// *Type: `String`*
+    UserConfigPath = sys::ETrackedDeviceProperty_Prop_UserConfigPath_String,
+    /// *Type: `String`*
+    InstallPath = sys::ETrackedDeviceProperty_Prop_InstallPath_String,
+    /// *Type: `bool`*
+    HasDisplayComponent = sys::ETrackedDeviceProperty_Prop_HasDisplayComponent_Bool,
+    /// *Type: `bool`*
+    HasControllerComponent = sys::ETrackedDeviceProperty_Prop_HasControllerComponent_Bool,
+    /// *Type: `bool`*
+    HasCameraComponent = sys::ETrackedDeviceProperty_Prop_HasCameraComponent_Bool,
+    /// *Type: `bool`*
+    HasDriverDirectModeComponent = sys::ETrackedDeviceProperty_Prop_HasDriverDirectModeComponent_Bool,
+    /// *Type: `bool`*
+    HasVirtualDisplayComponent = sys::ETrackedDeviceProperty_Prop_HasVirtualDisplayComponent_Bool,
+}
+impl Into<u32> for Property {
+    // In Rust 2018, we would've written this as `From<Property> for u32`. This crate is on 2015, though.
+    fn into(self) -> u32 {
+        // This is guaranteed to be 100% safe, thanks to #[repr(u32)].
+        unsafe {std::mem::transmute(self)}
+    }
+}
+
+/// A 3x4 matrix, as a tracked device property value.
+pub type Matrix34 = [[f32; 4]; 3];
+
+/// For types which can be extracted from a tracked device property.
+pub trait PropertyValue: Sized {
+    /// Returns the specified tracked device property.
+    ///
+    /// # Errors
+    /// See `TrackedPropertyError`.
+    fn get_property(device: TrackedDevice, property: Property) -> Result<Self, TrackedDevicePropertyError>;
+}
+
+impl PropertyValue for bool {
+    fn get_property(device: TrackedDevice, property: Property) -> Result<Self, TrackedDevicePropertyError> {
+        unsafe {
+            let mut error: TrackedDevicePropertyError = mem::uninitialized();
+            let r = device.system().0.GetBoolTrackedDeviceProperty.unwrap()(device.index(), property.into(), &mut error.0);
+            if error == TrackedDevicePropertyError::SUCCESS {
+                Ok(r)
+            } else {
+                Err(error)
+            }
+        }
+    }
+}
+impl PropertyValue for f32 {
+    fn get_property(device: TrackedDevice, property: Property) -> Result<Self, TrackedDevicePropertyError> {
+        unsafe {
+            let mut error: TrackedDevicePropertyError = mem::uninitialized();
+            let r = device.system().0.GetFloatTrackedDeviceProperty.unwrap()(device.index(), property.into(), &mut error.0);
+            if error == TrackedDevicePropertyError::SUCCESS {
+                Ok(r)
+            } else {
+                Err(error)
+            }
+        }
+    }
+}
+impl PropertyValue for i32 {
+    fn get_property(device: TrackedDevice, property: Property) -> TrackedDevicePropertyResult<Self> {
+        unsafe {
+            let mut error: TrackedDevicePropertyError = mem::uninitialized();
+            let r = device.system().0.GetInt32TrackedDeviceProperty.unwrap()(device.index(), property.into(), &mut error.0);
+            if error == TrackedDevicePropertyError::SUCCESS {
+                Ok(r)
+            } else {
+                Err(error)
+            }
+        }
+    }
+}
+impl PropertyValue for u64 {
+    fn get_property(device: TrackedDevice, property: Property) -> TrackedDevicePropertyResult<Self> {
+        unsafe {
+            let mut error: TrackedDevicePropertyError = mem::uninitialized();
+            let r = device.system().0.GetUint64TrackedDeviceProperty.unwrap()(device.index(), property.into(), &mut error.0);
+            if error == TrackedDevicePropertyError::SUCCESS {
+                Ok(r)
+            } else {
+                Err(error)
+            }
+        }
+    }
+}
+impl PropertyValue for Matrix34 {
+    fn get_property(device: TrackedDevice, property: Property) -> TrackedDevicePropertyResult<Self> {
+        unsafe {
+            let mut error: TrackedDevicePropertyError = mem::uninitialized();
+            let r =
+                device.system().0.GetMatrix34TrackedDeviceProperty.unwrap()(device.index(), property.into(), &mut error.0);
+            if error == TrackedDevicePropertyError::SUCCESS {
+                Ok(r.m)
+            } else {
+                Err(error)
+            }
+        }
+    }
+}
+impl PropertyValue for std::ffi::CString {
+    fn get_property(device: TrackedDevice, property: Property) -> TrackedDevicePropertyResult<Self> {
+        unsafe {
+            let mut error = mem::uninitialized();
+            let res = get_string(|ptr, n| {
+                device.system().0.GetStringTrackedDeviceProperty.unwrap()(device.index(), property.into(), ptr, n, &mut error)
+            });
+            res.map_or(Err(TrackedDevicePropertyError(error)), Ok)
+        }
+    }
+}
+
+/// The result of fetching a property of a tracked device.
+pub type TrackedDevicePropertyResult<T> = Result<T, TrackedDevicePropertyError>;
+/// The error that occurs whenever retrieving a tracked device property fails.
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct TrackedDevicePropertyError(sys::TrackedPropertyError);
+impl TrackedDevicePropertyError {
+    pub const SUCCESS: Self =
+        TrackedDevicePropertyError(sys::ETrackedPropertyError_TrackedProp_Success);
+    pub const WRONG_DATA_TYPE: Self =
+        TrackedDevicePropertyError(sys::ETrackedPropertyError_TrackedProp_WrongDataType);
+    pub const WRONG_DEVICE_CLASS: Self =
+        TrackedDevicePropertyError(sys::ETrackedPropertyError_TrackedProp_WrongDeviceClass);
+    pub const BUFFER_TOO_SMALL: Self =
+        TrackedDevicePropertyError(sys::ETrackedPropertyError_TrackedProp_BufferTooSmall);
+    pub const UNKNOWN_PROPERTY: Self =
+        TrackedDevicePropertyError(sys::ETrackedPropertyError_TrackedProp_UnknownProperty);
+    pub const INVALID_DEVICE: Self =
+        TrackedDevicePropertyError(sys::ETrackedPropertyError_TrackedProp_InvalidDevice);
+    pub const COULD_NOT_CONTACT_SERVER: Self =
+        TrackedDevicePropertyError(sys::ETrackedPropertyError_TrackedProp_CouldNotContactServer);
+    pub const VALUE_NOT_PROVIDED_BY_DEVICE: Self =
+        TrackedDevicePropertyError(sys::ETrackedPropertyError_TrackedProp_ValueNotProvidedByDevice);
+    pub const STRING_EXCEEDS_MAXIMUM_LENGTH: Self =
+        TrackedDevicePropertyError(sys::ETrackedPropertyError_TrackedProp_StringExceedsMaximumLength);
+    pub const NOT_YET_AVAILABLE: Self =
+        TrackedDevicePropertyError(sys::ETrackedPropertyError_TrackedProp_NotYetAvailable);
+    pub const PERMISSION_DENIED: Self =
+        TrackedDevicePropertyError(sys::ETrackedPropertyError_TrackedProp_PermissionDenied);
+    pub const INVALID_OPERATION: Self =
+        TrackedDevicePropertyError(sys::ETrackedPropertyError_TrackedProp_InvalidOperation);
+}
+
+impl fmt::Debug for TrackedDevicePropertyError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.pad(std::error::Error::description(self))
+    }
+}
+impl fmt::Display for TrackedDevicePropertyError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.pad(std::error::Error::description(self))
+    }
+}
+impl std::error::Error for TrackedDevicePropertyError {
+    fn description(&self) -> &str {
+        match *self {
+            Self::SUCCESS => "SUCCESS",
+            Self::WRONG_DATA_TYPE => "WRONG_DATA_TYPE",
+            Self::WRONG_DEVICE_CLASS => "WRONG_DEVICE_CLASS",
+            Self::BUFFER_TOO_SMALL => "BUFFER_TOO_SMALL",
+            Self::UNKNOWN_PROPERTY => "UNKNOWN_PROPERTY",
+            Self::INVALID_DEVICE => "INVALID_DEVICE",
+            Self::COULD_NOT_CONTACT_SERVER => "COULD_NOT_CONTACT_SERVER",
+            Self::VALUE_NOT_PROVIDED_BY_DEVICE => "VALUE_NOT_PROVIDED_BY_DEVICE",
+            Self::STRING_EXCEEDS_MAXIMUM_LENGTH => "STRING_EXCEEDS_MAXIMUM_LENGTH",
+            Self::NOT_YET_AVAILABLE => "NOT_YET_AVAILABLE",
+            Self::PERMISSION_DENIED => "PERMISSION_DENIED",
+            Self::INVALID_OPERATION => "INVALID_OPERATION",
+            _ => "UNKNOWN",
+        }
+    }
+}

--- a/src/system/event.rs
+++ b/src/system/event.rs
@@ -1,7 +1,9 @@
-pub struct EventInfo {
-    /// The tracked device index of the event. For events that aren't connected to a tracked device this is
+use crate::{tracking::TrackedDevice, System};
+
+pub struct EventInfo<'a> {
+    /// The tracked device of the event. For events that aren't connected to a tracked device this is
     /// k_unTrackedDeviceIndexInvalid
-    pub tracked_device_index: TrackedDeviceIndex,
+    pub tracked_device: TrackedDevice<'a>,
 
     /// The age of the event in seconds.
     pub age: f32,
@@ -10,19 +12,19 @@ pub struct EventInfo {
     pub event: Event,
 }
 
-impl From<sys::VREvent_t> for EventInfo {
+impl<'a> From<(sys::VREvent_t, &'a System)> for EventInfo<'a> {
     #[allow(unused_unsafe)]
-    fn from(x: sys::VREvent_t) -> Self {
+    fn from(op: (sys::VREvent_t, &'a System)) -> Self {
         EventInfo {
-            tracked_device_index: x.trackedDeviceIndex,
-            age: x.eventAgeSeconds,
-            event: Event::from_sys(x.eventType as sys::EVREventType, unsafe { &x.data }),
+            tracked_device: TrackedDevice::from_system_and_index(op.1, op.0.trackedDeviceIndex),
+            age: op.0.eventAgeSeconds,
+            event: Event::from_sys(op.0.eventType as sys::EVREventType, unsafe { &op.0.data }),
         }
     }
 }
 
 trait FromEventData {
-    unsafe fn from_event_data(x: &sys::VREvent_Data_t) -> Self;
+    unsafe fn from_event_data(ed: &sys::VREvent_Data_t) -> Self;
 }
 
 use super::*;

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -1,15 +1,13 @@
 //! The `System` interface provides access to display configuration information, tracking data, controller state,
 //! events, and device properties. It is the main interface of OpenVR.
 
-use std::marker::PhantomData;
-use std::{mem, ptr, slice};
+use std::{mem, ptr, slice, marker::PhantomData};
 
 use openvr_sys as sys;
 
 pub mod event;
 
 use super::*;
-
 pub use self::event::{Event, EventInfo};
 
 impl System {
@@ -160,22 +158,21 @@ impl System {
     ///
     /// # Safety
     /// The instance handle must be valid.
-    #[cfg(feature = "vulkan")]
     pub unsafe fn vulkan_output_device(
         &self,
-        instance: vk_sys::Instance,
-    ) -> Option<vk_sys::PhysicalDevice> {
+        instance: interop::vulkan::Instance,
+    ) -> Option<interop::vulkan::PhysicalDevice> {
         unsafe {
             let mut device = mem::uninitialized();
             self.0.GetOutputDevice.unwrap()(
                 &mut device,
                 sys::ETextureType_TextureType_Vulkan,
-                std::mem::transmute(instance), // FIXME: The syscrate for OpenVR should use vk-sys too, then we'd be able to remove this
+                instance as _,
             );
             if device == 0 {
                 None
             } else {
-                Some(std::convert::TryInto::<usize>::try_into(device).unwrap())
+                Some(device as _)
             }
         }
     }

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -1,7 +1,6 @@
 //! The `System` interface provides access to display configuration information, tracking data, controller state,
 //! events, and device properties. It is the main interface of OpenVR.
 
-use std::ffi::CString;
 use std::marker::PhantomData;
 use std::{mem, ptr, slice};
 
@@ -102,23 +101,6 @@ impl System {
         }
     }
 
-    pub fn tracked_device_class(&self, index: TrackedDeviceIndex) -> TrackedDeviceClass {
-        use self::TrackedDeviceClass::*;
-        match unsafe { self.0.GetTrackedDeviceClass.unwrap()(index) } {
-            sys::ETrackedDeviceClass_TrackedDeviceClass_Invalid => Invalid,
-            sys::ETrackedDeviceClass_TrackedDeviceClass_HMD => HMD,
-            sys::ETrackedDeviceClass_TrackedDeviceClass_Controller => Controller,
-            sys::ETrackedDeviceClass_TrackedDeviceClass_GenericTracker => GenericTracker,
-            sys::ETrackedDeviceClass_TrackedDeviceClass_TrackingReference => TrackingReference,
-            sys::ETrackedDeviceClass_TrackedDeviceClass_DisplayRedirect => DisplayRedirect,
-            _ => Invalid,
-        }
-    }
-
-    pub fn is_tracked_device_connected(&self, index: TrackedDeviceIndex) -> bool {
-        unsafe { self.0.IsTrackedDeviceConnected.unwrap()(index) }
-    }
-
     pub fn poll_next_event_with_pose(
         &self,
         origin: TrackingUniverseOrigin,
@@ -133,7 +115,7 @@ impl System {
                 &mut pose as *mut _ as *mut _,
             )
         } {
-            Some((event.into(), pose))
+            Some(((event, self).into(), pose))
         } else {
             None
         }
@@ -157,11 +139,11 @@ impl System {
         })
     }
 
-    /// Returns the device index associated with a specific role, for example the left hand or the right hand.
-    pub fn tracked_device_index_for_controller_role(
+    /// Returns the tracked device associated with a specific role, for example the left hand or the right hand.
+    pub fn tracked_device_for_controller_role(
         &self,
         role: TrackedControllerRole,
-    ) -> Option<TrackedDeviceIndex> {
+    ) -> Option<TrackedDevice> {
         let x = unsafe {
             self.0.GetTrackedDeviceIndexForControllerRole.unwrap()(
                 role as sys::ETrackedControllerRole,
@@ -170,138 +152,31 @@ impl System {
         if x == tracked_device_index::INVALID {
             None
         } else {
-            Some(x)
+            Some(TrackedDevice::from_system_and_index(self, x))
         }
     }
 
-    /// Returns the controller type associated with a device index.
-    pub fn get_controller_role_for_tracked_device_index(
+    /// Returns the output device used by OpenVR.
+    ///
+    /// # Safety
+    /// The instance handle must be valid.
+    #[cfg(feature = "vulkan")]
+    pub unsafe fn vulkan_output_device(
         &self,
-        i: TrackedDeviceIndex,
-    ) -> Option<TrackedControllerRole> {
-        let x = unsafe { self.0.GetControllerRoleForTrackedDeviceIndex.unwrap()(i) };
-        match x {
-            sys::ETrackedControllerRole_TrackedControllerRole_LeftHand => {
-                Some(TrackedControllerRole::LeftHand)
-            }
-            sys::ETrackedControllerRole_TrackedControllerRole_RightHand => {
-                Some(TrackedControllerRole::RightHand)
-            }
-            _ => None,
-        }
-    }
-
-    pub fn vulkan_output_device(
-        &self,
-        instance: *mut VkInstance_T,
-    ) -> Option<*mut VkPhysicalDevice_T> {
+        instance: vk_sys::Instance,
+    ) -> Option<vk_sys::PhysicalDevice> {
         unsafe {
             let mut device = mem::uninitialized();
             self.0.GetOutputDevice.unwrap()(
                 &mut device,
                 sys::ETextureType_TextureType_Vulkan,
-                instance,
+                std::mem::transmute(instance), // FIXME: The syscrate for OpenVR should use vk-sys too, then we'd be able to remove this
             );
             if device == 0 {
                 None
             } else {
-                Some(device as usize as *mut _)
+                Some(std::convert::TryInto::<usize>::try_into(device).unwrap())
             }
-        }
-    }
-
-    pub fn bool_tracked_device_property(
-        &self,
-        device: TrackedDeviceIndex,
-        property: TrackedDeviceProperty,
-    ) -> Result<bool, TrackedPropertyError> {
-        unsafe {
-            let mut error: TrackedPropertyError = mem::uninitialized();
-            let r = self.0.GetBoolTrackedDeviceProperty.unwrap()(device, property, &mut error.0);
-            if error == tracked_property_error::SUCCESS {
-                Ok(r)
-            } else {
-                Err(error)
-            }
-        }
-    }
-
-    pub fn float_tracked_device_property(
-        &self,
-        device: TrackedDeviceIndex,
-        property: TrackedDeviceProperty,
-    ) -> Result<f32, TrackedPropertyError> {
-        unsafe {
-            let mut error: TrackedPropertyError = mem::uninitialized();
-            let r = self.0.GetFloatTrackedDeviceProperty.unwrap()(device, property, &mut error.0);
-            if error == tracked_property_error::SUCCESS {
-                Ok(r)
-            } else {
-                Err(error)
-            }
-        }
-    }
-
-    pub fn int32_tracked_device_property(
-        &self,
-        device: TrackedDeviceIndex,
-        property: TrackedDeviceProperty,
-    ) -> Result<i32, TrackedPropertyError> {
-        unsafe {
-            let mut error: TrackedPropertyError = mem::uninitialized();
-            let r = self.0.GetInt32TrackedDeviceProperty.unwrap()(device, property, &mut error.0);
-            if error == tracked_property_error::SUCCESS {
-                Ok(r)
-            } else {
-                Err(error)
-            }
-        }
-    }
-
-    pub fn uint64_tracked_device_property(
-        &self,
-        device: TrackedDeviceIndex,
-        property: TrackedDeviceProperty,
-    ) -> Result<u64, TrackedPropertyError> {
-        unsafe {
-            let mut error: TrackedPropertyError = mem::uninitialized();
-            let r = self.0.GetUint64TrackedDeviceProperty.unwrap()(device, property, &mut error.0);
-            if error == tracked_property_error::SUCCESS {
-                Ok(r)
-            } else {
-                Err(error)
-            }
-        }
-    }
-
-    pub fn matrix34_tracked_device_property(
-        &self,
-        device: TrackedDeviceIndex,
-        property: TrackedDeviceProperty,
-    ) -> Result<[[f32; 4]; 3], TrackedPropertyError> {
-        unsafe {
-            let mut error: TrackedPropertyError = mem::uninitialized();
-            let r =
-                self.0.GetMatrix34TrackedDeviceProperty.unwrap()(device, property, &mut error.0);
-            if error == tracked_property_error::SUCCESS {
-                Ok(r.m)
-            } else {
-                Err(error)
-            }
-        }
-    }
-
-    pub fn string_tracked_device_property(
-        &self,
-        device: TrackedDeviceIndex,
-        property: TrackedDeviceProperty,
-    ) -> Result<CString, TrackedPropertyError> {
-        unsafe {
-            let mut error = mem::uninitialized();
-            let res = get_string(|ptr, n| {
-                self.0.GetStringTrackedDeviceProperty.unwrap()(device, property, ptr, n, &mut error)
-            });
-            res.map_or(Err(TrackedPropertyError(error)), Ok)
         }
     }
 
@@ -441,71 +316,6 @@ pub struct DistortionCoordinates {
     pub red: [f32; 2],
     pub green: [f32; 2],
     pub blue: [f32; 2],
-}
-
-#[derive(Copy, Clone, Eq, PartialEq)]
-pub struct TrackedPropertyError(sys::TrackedPropertyError);
-
-pub mod tracked_property_error {
-    use super::{sys, TrackedPropertyError};
-
-    pub const SUCCESS: TrackedPropertyError =
-        TrackedPropertyError(sys::ETrackedPropertyError_TrackedProp_Success);
-    pub const WRONG_DATA_TYPE: TrackedPropertyError =
-        TrackedPropertyError(sys::ETrackedPropertyError_TrackedProp_WrongDataType);
-    pub const WRONG_DEVICE_CLASS: TrackedPropertyError =
-        TrackedPropertyError(sys::ETrackedPropertyError_TrackedProp_WrongDeviceClass);
-    pub const BUFFER_TOO_SMALL: TrackedPropertyError =
-        TrackedPropertyError(sys::ETrackedPropertyError_TrackedProp_BufferTooSmall);
-    pub const UNKNOWN_PROPERTY: TrackedPropertyError =
-        TrackedPropertyError(sys::ETrackedPropertyError_TrackedProp_UnknownProperty);
-    pub const INVALID_DEVICE: TrackedPropertyError =
-        TrackedPropertyError(sys::ETrackedPropertyError_TrackedProp_InvalidDevice);
-    pub const COULD_NOT_CONTACT_SERVER: TrackedPropertyError =
-        TrackedPropertyError(sys::ETrackedPropertyError_TrackedProp_CouldNotContactServer);
-    pub const VALUE_NOT_PROVIDED_BY_DEVICE: TrackedPropertyError =
-        TrackedPropertyError(sys::ETrackedPropertyError_TrackedProp_ValueNotProvidedByDevice);
-    pub const STRING_EXCEEDS_MAXIMUM_LENGTH: TrackedPropertyError =
-        TrackedPropertyError(sys::ETrackedPropertyError_TrackedProp_StringExceedsMaximumLength);
-    pub const NOT_YET_AVAILABLE: TrackedPropertyError =
-        TrackedPropertyError(sys::ETrackedPropertyError_TrackedProp_NotYetAvailable);
-    pub const PERMISSION_DENIED: TrackedPropertyError =
-        TrackedPropertyError(sys::ETrackedPropertyError_TrackedProp_PermissionDenied);
-    pub const INVALID_OPERATION: TrackedPropertyError =
-        TrackedPropertyError(sys::ETrackedPropertyError_TrackedProp_InvalidOperation);
-}
-
-impl fmt::Debug for TrackedPropertyError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.pad(::std::error::Error::description(self))
-    }
-}
-
-impl ::std::error::Error for TrackedPropertyError {
-    fn description(&self) -> &str {
-        use self::tracked_property_error::*;
-        match *self {
-            SUCCESS => "SUCCESS",
-            WRONG_DATA_TYPE => "WRONG_DATA_TYPE",
-            WRONG_DEVICE_CLASS => "WRONG_DEVICE_CLASS",
-            BUFFER_TOO_SMALL => "BUFFER_TOO_SMALL",
-            UNKNOWN_PROPERTY => "UNKNOWN_PROPERTY",
-            INVALID_DEVICE => "INVALID_DEVICE",
-            COULD_NOT_CONTACT_SERVER => "COULD_NOT_CONTACT_SERVER",
-            VALUE_NOT_PROVIDED_BY_DEVICE => "VALUE_NOT_PROVIDED_BY_DEVICE",
-            STRING_EXCEEDS_MAXIMUM_LENGTH => "STRING_EXCEEDS_MAXIMUM_LENGTH",
-            NOT_YET_AVAILABLE => "NOT_YET_AVAILABLE",
-            PERMISSION_DENIED => "PERMISSION_DENIED",
-            INVALID_OPERATION => "INVALID_OPERATION",
-            _ => "UNKNOWN",
-        }
-    }
-}
-
-impl fmt::Display for TrackedPropertyError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.pad(::std::error::Error::description(self))
-    }
 }
 
 pub enum HiddenAreaMeshType {


### PR DESCRIPTION
This aims to fix #46 as thoroughly as possible. Most of the changes here are breaking. Here's a list of what I did as of now:
- ~~Removed Vulkan interop types and added an optional feature-guarded `vk-sys` dependency~~ Moved Vulkan interop types into a designated module which is expected to support other APIs in the future
- Revamped the `property` module to use a big `#[repr(u32)]` enum and a trait instead of multiple functions in `System`
- Added a `TrackedDevice` structure to replace the old `TrackedDeviceIndex`
- Minor documentation fixes