### PR TITLE
Remove most uses of mem::uninitialized

### DIFF
--- a/src/chaperone.rs
+++ b/src/chaperone.rs
@@ -69,8 +69,8 @@ impl From<sys::ChaperoneCalibrationState> for ChaperoneCalibrationState {
         use self::ChaperoneCalibrationState::*;
         match state {
             1 => Ok,
-            100...199 => Warning(ChaperoneCalibrationWarningState::from(state)),
-            200...299 => Error(ChaperoneCalibrationErrorState::from(state)),
+            100..=199 => Warning(ChaperoneCalibrationWarningState::from(state)),
+            200..=299 => Error(ChaperoneCalibrationErrorState::from(state)),
             _ => Unknown(state as u32),
         }
     }

--- a/src/compositor/mod.rs
+++ b/src/compositor/mod.rs
@@ -9,7 +9,7 @@
 //! camera render target to draw a single quad (perhaps cropped to a lower fov to hide the hidden area mask).
 
 use std::ffi::CString;
-use std::{error, fmt, mem, ptr};
+use std::{error, fmt, mem::MaybeUninit, ptr};
 
 use openvr_sys as sys;
 
@@ -61,15 +61,16 @@ impl Compositor {
     /// Poses are relative to the origin set by `set_tracking_space`.
     pub fn wait_get_poses(&self) -> Result<WaitPoses, CompositorError> {
         unsafe {
-            let mut result: WaitPoses = mem::uninitialized();
+            let mut render: MaybeUninit<TrackedDevicePoses> = MaybeUninit::uninit();
+            let mut game: MaybeUninit<TrackedDevicePoses> = MaybeUninit::uninit();
             let e = self.0.WaitGetPoses.unwrap()(
-                result.render.as_mut().as_mut_ptr() as *mut _,
-                result.render.len() as u32,
-                result.game.as_mut().as_mut_ptr() as *mut _,
-                result.game.len() as u32,
+                render.as_mut_ptr() as *mut _,
+                MAX_TRACKED_DEVICE_COUNT as u32,
+                game.as_mut_ptr() as *mut _,
+                MAX_TRACKED_DEVICE_COUNT as u32,
             );
             if e == sys::EVRCompositorError_VRCompositorError_None {
-                Ok(result)
+                Ok(WaitPoses{render: render.assume_init(), game: game.assume_init()})
             } else {
                 Err(CompositorError(e))
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@ extern crate openvr_sys;
 #[macro_use]
 extern crate lazy_static;
 
-use std::cell::Cell;
 use std::ffi::{CStr, CString};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::{error, fmt, mem, ptr};

--- a/src/render_models.rs
+++ b/src/render_models.rs
@@ -1,5 +1,5 @@
 use std::ffi::{CStr, CString};
-use std::{fmt, mem, ptr, slice};
+use std::{fmt, mem::MaybeUninit, ptr, slice};
 
 use openvr_sys as sys;
 
@@ -95,15 +95,15 @@ impl RenderModels {
         mode: &ControllerMode,
     ) -> Option<ComponentState> {
         unsafe {
-            let mut out = mem::uninitialized();
+            let mut out: MaybeUninit<ComponentState> = MaybeUninit::uninit();
             if self.0.GetComponentState.unwrap()(
                 model.as_ptr() as *mut _,
                 component.as_ptr() as *mut _,
                 state as *const _ as *mut _,
                 mode as *const _ as *mut _,
-                &mut out as *mut _ as *mut _,
+                out.as_mut_ptr() as *mut _ as *mut _,
             ) {
-                Some(out)
+                Some(out.assume_init())
             } else {
                 None
             }


### PR DESCRIPTION
Was looking into the library and saw a bunch of deprecation warnings due to using `mem::uninitialized`. Since I had played around with transforming them into `MaybeUninit` calls instead I applied that transformation to the project.

I left the usage in `get_string` because I haven't used uninitialized vectors enough to know the best way to handle them and saw that https://github.com/icewind1991/rust-openvr/commit/9dcdf7f567eda9b89d147cfedc089cd74ecc6354 was a much better fix than what I tried to do.