### PR TITLE
Switch from `mem::uninitialized()` to `mem::MaybeUninit::uninit()` in `poll_next_event_with_pose`. 

### DIFF
--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -123,8 +123,8 @@ impl System {
         &self,
         origin: TrackingUniverseOrigin,
     ) -> Option<(EventInfo, TrackedDevicePose)> {
-        let mut event = unsafe { mem::MaybeUninit::uninit() };
-        let mut pose = unsafe { mem::MaybeUninit::uninit() };
+        let mut event = mem::MaybeUninit::uninit();
+        let mut pose = mem::MaybeUninit::uninit();
         if unsafe {
             self.0.PollNextEventWithPose.unwrap()(
                 origin as sys::ETrackingUniverseOrigin,

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -123,17 +123,17 @@ impl System {
         &self,
         origin: TrackingUniverseOrigin,
     ) -> Option<(EventInfo, TrackedDevicePose)> {
-        let mut event = unsafe { mem::uninitialized() };
-        let mut pose = unsafe { mem::uninitialized() };
+        let mut event = unsafe { mem::MaybeUninit::uninit() };
+        let mut pose = unsafe { mem::MaybeUninit::uninit() };
         if unsafe {
             self.0.PollNextEventWithPose.unwrap()(
                 origin as sys::ETrackingUniverseOrigin,
-                &mut event,
+                event.as_mut_ptr(),
                 mem::size_of_val(&event) as u32,
-                &mut pose as *mut _ as *mut _,
+                pose.as_mut_ptr() as *mut _,
             )
         } {
-            Some((event.into(), pose))
+            unsafe { Some((event.assume_init().into(), pose.assume_init())) }
         } else {
             None
         }


### PR DESCRIPTION
This PR is a potential fix for the issue described in:
- #51


It replaces the offending uses of `mem::uninitialized()` with `mem::MaybeUninit::uninit()`, which causes `poll_next_event_with_pose` to work again.

_Please note that this is the first piece of Rust code I've ever committed, and that as such I don't fully understand whether this is the correct solution. Please verify my changes assuming I have no idea know what I am doing._