### PR TITLE
Implement submit for "DirectX" (d3d11)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,8 @@ maintenance = { status = "passively-maintained" }
 [dependencies]
 openvr_sys = "2.0.3"
 lazy_static = "1.3.0"
+windows = {version = "0.51.1", optional = true, features = ["Win32_Graphics_Direct3D11"]}
+
+[features]
+default = ["submit_d3d11"]
+submit_d3d11 = ["dep:windows"]

--- a/src/compositor/texture.rs
+++ b/src/compositor/texture.rs
@@ -1,3 +1,7 @@
+use std::ffi::c_void;
+
+use windows::Win32::Graphics::Direct3D11::ID3D11Texture2D;
+
 use super::{sys, VkDevice_T, VkInstance_T, VkPhysicalDevice_T, VkQueue_T};
 
 #[derive(Debug, Copy, Clone)]
@@ -37,6 +41,8 @@ pub enum Handle {
     Vulkan(vulkan::Texture),
     OpenGLTexture(usize),
     OpenGLRenderBuffer(usize),
+    #[cfg(feature = "submit_d3d11")]
+    DirectX(*mut ID3D11Texture2D),
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+extern crate windows;
+
 extern crate openvr_sys;
 #[macro_use]
 extern crate lazy_static;


### PR DESCRIPTION
Hello 👋 

Currently, this library does not allow you to submit DirectX textures to the SteamVR compositor.

This PR implements a code path to do it that works. This uses the types defined in the `windows` crate. 

https://microsoft.github.io/windows-docs-rs/doc/windows/Win32/Graphics/Direct3D11/struct.ID3D11Texture2D.html

`ID3D11Texture2D` is a COM interface wrapped by the `windows`  crate. In OpenVR you pass that pointer directly by casting it to `void*` in the submit call.

In the `windows` create, the required pointer is wrapped into a nice little struct, and some unsafe pointer manipulation (and technically accessing a private field) seems needed to obtain the right pointer to pass to `Compositor::Submit()`

As far as I can tell, this is the only way actually to obtain that pointer. Assuming the texture is valid (the same assumption the underlying C++ library does), this is "safe to do."  

I have gated the functionality behind a `submit_d3d11` feature but also enabled it by default for now. 

I am looking for feedback about this, as I am relatively new to Rust after many years of C++. It otherwise seems to work just fine!