### PR TITLE
Allow passing DirectX 11 textures to OpenVR

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,5 +27,5 @@ lazy_static = "1.3.0"
 windows = {version = "0.51.1", optional = true, features = ["Win32_Graphics_Direct3D11"]}
 
 [features]
-default = ["submit_d3d11"]
+default = []
 submit_d3d11 = ["dep:windows"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,8 @@ maintenance = { status = "passively-maintained" }
 [dependencies]
 openvr_sys = "2.0.3"
 lazy_static = "1.3.0"
+windows = {version = "0.51.1", optional = true, features = ["Win32_Graphics_Direct3D11"]}
+
+[features]
+default = ["submit_d3d11"]
+submit_d3d11 = ["dep:windows"]

--- a/src/compositor/mod.rs
+++ b/src/compositor/mod.rs
@@ -95,6 +95,8 @@ impl Compositor {
             Vulkan(_) => sys::EVRSubmitFlags_Submit_Default,
             OpenGLTexture(_) => sys::EVRSubmitFlags_Submit_Default,
             OpenGLRenderBuffer(_) => sys::EVRSubmitFlags_Submit_GlRenderBuffer,
+            #[cfg(feature = "submit_d3d11")]
+            DirectX(_) => sys::EVRSubmitFlags_Submit_Default,
         } | if pose.is_some() {
             sys::EVRSubmitFlags_Submit_TextureWithPose
         } else {
@@ -105,11 +107,18 @@ impl Compositor {
                 Vulkan(ref x) => x as *const _ as *mut _,
                 OpenGLTexture(x) => x as *mut _,
                 OpenGLRenderBuffer(x) => x as *mut _,
+                #[cfg(feature = "submit_d3d11")]
+                DirectX(x) => {
+                    use windows::core::Interface;
+                    x.as_ref().expect("COM pointer must be valid").as_raw()
+                }
             },
             eType: match texture.handle {
                 Vulkan(_) => sys::ETextureType_TextureType_Vulkan,
                 OpenGLTexture(_) => sys::ETextureType_TextureType_OpenGL,
                 OpenGLRenderBuffer(_) => sys::ETextureType_TextureType_OpenGL,
+                #[cfg(feature = "submit_d3d11")]
+                DirectX(_) => sys::ETextureType_TextureType_DirectX,
             },
             eColorSpace: texture.color_space as sys::EColorSpace,
             mDeviceToAbsoluteTracking: sys::HmdMatrix34_t {

--- a/src/compositor/texture.rs
+++ b/src/compositor/texture.rs
@@ -1,3 +1,7 @@
+use std::ffi::c_void;
+
+use windows::Win32::Graphics::Direct3D11::ID3D11Texture2D;
+
 use super::{sys, VkDevice_T, VkInstance_T, VkPhysicalDevice_T, VkQueue_T};
 
 #[derive(Debug, Copy, Clone)]
@@ -37,6 +41,8 @@ pub enum Handle {
     Vulkan(vulkan::Texture),
     OpenGLTexture(usize),
     OpenGLRenderBuffer(usize),
+    #[cfg(feature = "submit_d3d11")]
+    DirectX(*mut ID3D11Texture2D),
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "submit_d3d11")]
 extern crate windows;
 
 extern crate openvr_sys;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+extern crate windows;
+
 extern crate openvr_sys;
 #[macro_use]
 extern crate lazy_static;


### PR DESCRIPTION
This uses the types defined in the `windows` crate. ID3D11Texture2D is a COM interface. The Interface trait implement an `as_raw()` method. This is the pointer that needs to be passed to the SteamVR compositor at submit time.

Gated the functionality behind a `submit_d3d11` feature, but also enabled it by default for convenience. We can change that.