### PR TITLE
Update SDK to support new sys crate

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,23 +2,31 @@ name: Rust
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "*" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "*" ]
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   build:
-    name: "Build and test ${{ matrix.os }}"
-    runs-on:  ${{ matrix.os }}
+    name: "Build and test ${{ matrix.os }} with Rust ${{ matrix.rustc-version }}"
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macOS-latest]
+        rustc-version: [1.82.0, 1.83.0, 1.84.0]
+      fail-fast: false
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - name: Install Rust ${{ matrix.rustc-version }}
+      run: |
+        rustup install ${{ matrix.rustc-version }}
+        rustup default ${{ matrix.rustc-version }}
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,25 @@
+name: Rust
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: "Build and test ${{ matrix.os }}"
+    runs-on:  ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest, macOS-latest]
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ Cargo.lock
 
 /.idea/
 /.vscode/
+/.cargo/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,15 @@
 [package]
 name = "openvr"
-version = "0.6.0"
+version = "0.7.0"
 authors = [
     "Colin Sherratt",
     "Erick Tryzelaar",
     "Rene Eichhorn",
-    "Benjamin Saunders"
+    "Benjamin Saunders",
+    "Alexander Brook Perry", 
+    "Arthur Brainville"
 ]
+edition = "2021"
 license = "MIT"
 
 homepage = "https://github.com/rust-openvr/rust-openvr"
@@ -22,5 +25,10 @@ travis-ci = { repository = "rust-openvr/rust-openvr" }
 maintenance = { status = "passively-maintained" }
 
 [dependencies]
-openvr_sys = "2.0.3"
+openvr_sys = "2.1.1"
 lazy_static = "1.3.0"
+windows = {version = "0.51.1", optional = true, features = ["Win32_Graphics_Direct3D11"]}
+
+[features]
+default = []
+submit_d3d11 = ["dep:windows"]

--- a/src/chaperone.rs
+++ b/src/chaperone.rs
@@ -2,7 +2,7 @@ use std::convert::From;
 
 use openvr_sys as sys;
 
-use Chaperone;
+use crate::Chaperone;
 
 /// Chaperone warning states
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
@@ -69,8 +69,8 @@ impl From<sys::ChaperoneCalibrationState> for ChaperoneCalibrationState {
         use self::ChaperoneCalibrationState::*;
         match state {
             1 => Ok,
-            100...199 => Warning(ChaperoneCalibrationWarningState::from(state)),
-            200...299 => Error(ChaperoneCalibrationErrorState::from(state)),
+            100..=199 => Warning(ChaperoneCalibrationWarningState::from(state)),
+            200..=299 => Error(ChaperoneCalibrationErrorState::from(state)),
             _ => Unknown(state as u32),
         }
     }

--- a/src/compositor/texture.rs
+++ b/src/compositor/texture.rs
@@ -1,3 +1,7 @@
+
+#[cfg(feature = "submit_d3d11")]
+use windows::Win32::Graphics::Direct3D11::ID3D11Texture2D;
+
 use super::{sys, VkDevice_T, VkInstance_T, VkPhysicalDevice_T, VkQueue_T};
 
 #[derive(Debug, Copy, Clone)]
@@ -28,8 +32,8 @@ pub mod vulkan {
         pub format: u32,
         pub sample_count: u32,
     }
-    unsafe impl Send for Texture{}
-    unsafe impl Sync for Texture{}
+    unsafe impl Send for Texture {}
+    unsafe impl Sync for Texture {}
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -37,6 +41,8 @@ pub enum Handle {
     Vulkan(vulkan::Texture),
     OpenGLTexture(usize),
     OpenGLRenderBuffer(usize),
+    #[cfg(feature = "submit_d3d11")]
+    DirectX(*mut ID3D11Texture2D),
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]

--- a/src/system/event.rs
+++ b/src/system/event.rs
@@ -13,7 +13,9 @@ pub struct EventInfo {
 impl From<sys::VREvent_t> for EventInfo {
     #[allow(unused_unsafe)]
     fn from(x: sys::VREvent_t) -> Self {
-        let data = x.data; // workaround E0793 on linux/mac 
+        // workaround unaligned reference to a field of a packed struct (E0793) on linux/mac 
+        // https://doc.rust-lang.org/error_codes/E0793.html
+        let data = x.data; 
         EventInfo {
             tracked_device_index: x.trackedDeviceIndex,
             age: x.eventAgeSeconds,

--- a/src/system/event.rs
+++ b/src/system/event.rs
@@ -13,10 +13,11 @@ pub struct EventInfo {
 impl From<sys::VREvent_t> for EventInfo {
     #[allow(unused_unsafe)]
     fn from(x: sys::VREvent_t) -> Self {
+        let data = x.data; // workaround E0793 on linux/mac 
         EventInfo {
             tracked_device_index: x.trackedDeviceIndex,
             age: x.eventAgeSeconds,
-            event: Event::from_sys(x.eventType as sys::EVREventType, unsafe { &x.data }),
+            event: Event::from_sys(x.eventType as sys::EVREventType, &data),
         }
     }
 }
@@ -208,14 +209,6 @@ pub enum Event {
     ButtonUnpress(Controller),
     ButtonTouch(Controller),
     ButtonUntouch(Controller),
-    DualAnalog_Press,
-    DualAnalog_Unpress,
-    DualAnalog_Touch,
-    DualAnalog_Untouch,
-    DualAnalog_Move,
-    DualAnalog_ModeSwitch1,
-    DualAnalog_ModeSwitch2,
-    DualAnalog_Cancel,
     MouseMove(Mouse),
     MouseButtonDown(Mouse),
     MouseButtonUp(Mouse),
@@ -231,8 +224,6 @@ pub enum Event {
     InputFocusCaptured(Process),
     #[deprecated]
     InputFocusReleased(Process),
-    SceneFocusLost(Process),
-    SceneFocusGained(Process),
     /// The app actually drawing the scene changed (usually to or from the compositor)
     SceneApplicationChanged(Process),
     /// New app got access to draw the scene
@@ -255,8 +246,6 @@ pub enum Event {
     DashboardRequested,
     /// Send to the overlay manager
     ResetDashboard,
-    /// Send to the dashboard to render a toast - data is the notification ID
-    RenderToast,
     /// Sent to overlays when a SetOverlayRaw or SetOverlayFromFile call finishes loading
     ImageLoaded,
     /// Sent to keyboard renderer in the dashboard to invoke it
@@ -296,7 +285,6 @@ pub enum Event {
     /// The application has been asked to quit
     Quit(Process),
     ProcessQuit(Process),
-    QuitAborted_UserPrompt(Process),
     QuitAcknowledged(Process),
     /// The driver has requested that SteamVR shut down
     DriverRequestedQuit,
@@ -338,16 +326,10 @@ pub enum Event {
     KeyboardCharInput(Keyboard),
     /// Sent when DONE button clicked on keyboard
     KeyboardDone,
-    ApplicationTransitionStarted,
-    ApplicationTransitionAborted,
-    ApplicationTransitionNewAppStarted,
     ApplicationListUpdated,
     ApplicationMimeTypeLoad,
-    ApplicationTransitionNewAppLaunchComplete,
     ProcessConnected,
     ProcessDisconnected,
-    Compositor_MirrorWindowShown,
-    Compositor_MirrorWindowHidden,
     Compositor_ChaperoneBoundsShown,
     Compositor_ChaperoneBoundsHidden,
     Compositor_DisplayDisconnected,
@@ -416,14 +398,6 @@ impl Event {
             sys::EVREventType_VREvent_ButtonUnpress => ButtonUnpress(get(data)),
             sys::EVREventType_VREvent_ButtonTouch => ButtonTouch(get(data)),
             sys::EVREventType_VREvent_ButtonUntouch => ButtonUntouch(get(data)),
-            sys::EVREventType_VREvent_DualAnalog_Press => DualAnalog_Press,
-            sys::EVREventType_VREvent_DualAnalog_Unpress => DualAnalog_Unpress,
-            sys::EVREventType_VREvent_DualAnalog_Touch => DualAnalog_Touch,
-            sys::EVREventType_VREvent_DualAnalog_Untouch => DualAnalog_Untouch,
-            sys::EVREventType_VREvent_DualAnalog_Move => DualAnalog_Move,
-            sys::EVREventType_VREvent_DualAnalog_ModeSwitch1 => DualAnalog_ModeSwitch1,
-            sys::EVREventType_VREvent_DualAnalog_ModeSwitch2 => DualAnalog_ModeSwitch2,
-            sys::EVREventType_VREvent_DualAnalog_Cancel => DualAnalog_Cancel,
             sys::EVREventType_VREvent_MouseMove => MouseMove(get(data)),
             sys::EVREventType_VREvent_MouseButtonDown => MouseButtonDown(get(data)),
             sys::EVREventType_VREvent_MouseButtonUp => MouseButtonUp(get(data)),
@@ -436,14 +410,8 @@ impl Event {
             sys::EVREventType_VREvent_ScrollSmooth => ScrollSmooth(get(data)),
             sys::EVREventType_VREvent_InputFocusCaptured => InputFocusCaptured(get(data)),
             sys::EVREventType_VREvent_InputFocusReleased => InputFocusReleased(get(data)),
-            sys::EVREventType_VREvent_SceneFocusLost => SceneFocusLost(get(data)),
-            sys::EVREventType_VREvent_SceneFocusGained => SceneFocusGained(get(data)),
             sys::EVREventType_VREvent_SceneApplicationChanged => SceneApplicationChanged(get(data)),
-            sys::EVREventType_VREvent_SceneFocusChanged => SceneFocusChanged(get(data)),
             sys::EVREventType_VREvent_InputFocusChanged => InputFocusChanged(get(data)),
-            sys::EVREventType_VREvent_SceneApplicationSecondaryRenderingStarted => {
-                SceneApplicationSecondaryRenderingStarted(get(data))
-            }
             sys::EVREventType_VREvent_SceneApplicationUsingWrongGraphicsAdapter => {
                 SceneApplicationUsingWrongGraphicsAdapter
             }
@@ -458,7 +426,6 @@ impl Event {
             sys::EVREventType_VREvent_DashboardDeactivated => DashboardDeactivated,
             sys::EVREventType_VREvent_DashboardRequested => DashboardRequested,
             sys::EVREventType_VREvent_ResetDashboard => ResetDashboard,
-            sys::EVREventType_VREvent_RenderToast => RenderToast,
             sys::EVREventType_VREvent_ImageLoaded => ImageLoaded,
             sys::EVREventType_VREvent_ShowKeyboard => ShowKeyboard,
             sys::EVREventType_VREvent_HideKeyboard => HideKeyboard,
@@ -491,7 +458,6 @@ impl Event {
             sys::EVREventType_VREvent_Notification_Destroyed => Notification_Destroyed,
             sys::EVREventType_VREvent_Quit => Quit(get(data)),
             sys::EVREventType_VREvent_ProcessQuit => ProcessQuit(get(data)),
-            sys::EVREventType_VREvent_QuitAborted_UserPrompt => QuitAborted_UserPrompt(get(data)),
             sys::EVREventType_VREvent_QuitAcknowledged => QuitAcknowledged(get(data)),
             sys::EVREventType_VREvent_DriverRequestedQuit => DriverRequestedQuit,
             sys::EVREventType_VREvent_RestartRequested => RestartRequested,
@@ -557,22 +523,10 @@ impl Event {
             sys::EVREventType_VREvent_KeyboardClosed => KeyboardClosed,
             sys::EVREventType_VREvent_KeyboardCharInput => KeyboardCharInput(get(data)),
             sys::EVREventType_VREvent_KeyboardDone => KeyboardDone,
-            sys::EVREventType_VREvent_ApplicationTransitionStarted => ApplicationTransitionStarted,
-            sys::EVREventType_VREvent_ApplicationTransitionAborted => ApplicationTransitionAborted,
-            sys::EVREventType_VREvent_ApplicationTransitionNewAppStarted => {
-                ApplicationTransitionNewAppStarted
-            }
             sys::EVREventType_VREvent_ApplicationListUpdated => ApplicationListUpdated,
             sys::EVREventType_VREvent_ApplicationMimeTypeLoad => ApplicationMimeTypeLoad,
-            sys::EVREventType_VREvent_ApplicationTransitionNewAppLaunchComplete => {
-                ApplicationTransitionNewAppLaunchComplete
-            }
             sys::EVREventType_VREvent_ProcessConnected => ProcessConnected,
             sys::EVREventType_VREvent_ProcessDisconnected => ProcessDisconnected,
-            sys::EVREventType_VREvent_Compositor_MirrorWindowShown => Compositor_MirrorWindowShown,
-            sys::EVREventType_VREvent_Compositor_MirrorWindowHidden => {
-                Compositor_MirrorWindowHidden
-            }
             sys::EVREventType_VREvent_Compositor_ChaperoneBoundsShown => {
                 Compositor_ChaperoneBoundsShown
             }

--- a/src/tracking.rs
+++ b/src/tracking.rs
@@ -69,8 +69,8 @@ pub type TrackedDeviceIndex = sys::TrackedDeviceIndex_t;
 
 pub mod tracked_device_index {
     use super::*;
-    pub const HMD: TrackedDeviceIndex = sys::k_unTrackedDeviceIndex_Hmd;
-    pub const INVALID: TrackedDeviceIndex = sys::k_unTrackedDeviceIndexInvalid;
+    pub const HMD: TrackedDeviceIndex = sys::k_unTrackedDeviceIndex_Hmd as TrackedDeviceIndex;
+    pub const INVALID: TrackedDeviceIndex = sys::k_unTrackedDeviceIndexInvalid as TrackedDeviceIndex;
 }
 
 pub type TrackedDeviceProperty = sys::ETrackedDeviceProperty;


### PR DESCRIPTION
* Allow passing DirectX 11 textures to OpenVR

This uses the types defined in the `windows` crate. ID3D11Texture2D is a
COM interface. The Interface trait implement an `as_raw()` method. This
is the pointer that needs to be passed to the SteamVR compositor at
submit time.

Gated the functionality behind a `submit_d3d11` feature, but also
enabled it by default for convenience. We can change that.

* Disable submit_d3d11 configuration

* Configuration guard on import as it caused compile error when not specifying feature 'submit_d3d11'.

* Remove acknowledge_quit_user_prompt as AcknowledgeQuit_UserPrompt has been removed. Remove reset_seated_zero_pose as ResetSeatedZeroPose moved into IVRChaperone - there are several methods on IVRChaperone including this that can be added later. Fixed deprecated form of range matching in chaperone.rs. Use proper crate relative imports.

* Remove EVREventType_VREvent_DualAnalog_Press, EVREventType_VREvent_DualAnalog_Unpress, EVREventType_VREvent_DualAnalog_Touch, EVREventType_VREvent_DualAnalog_Untouch, EVREventType_VREvent_DualAnalog_Move, EVREventType_VREvent_DualAnalog_ModeSwitch1, EVREventType_VREvent_DualAnalog_ModeSwitch2, and EVREventType_VREvent_DualAnalog_Cancel as they have been deprecated and removed in favour of just EVREventType_VREvent_* events.

* Remove EVREventType_VREvent_SceneFocusLost, EVREventType_VREvent_SceneFocusGained, and EVREventType_VREvent_SceneApplicationSecondaryRenderingStarted as they were removed in v1.8.19 (no reason given). Like removed EVREventType_VREvent_SceneFocusChanged as it removed in v1.26.7 (reason being "defunct"). Removed EVREventType_VREvent_RenderToast, I cannot find any changelogs related to when or why it was removed. Removed EVREventType_VREvent_QuitAborted_UserPrompt removed in v1.8.19 as "Prompt user on quit" functionality is no longer supported. Removed EVREventType_VREvent_ApplicationTransitionStarted, EVREventType_VREvent_ApplicationTransitionAborted, EVREventType_VREvent_ApplicationTransitionNewAppStarted, andEVREventType_VREvent_ApplicationTransitionNewAppLaunchComplete removed in v1.8.19 (no reason given). Removed EVREventType_VREvent_Compositor_MirrorWindowShown and EVREventType_VREvent_Compositor_MirrorWindowHidden, no changelogs for these.

* Remove enums from Event that no longer have corresponding events in OpenVR due to deprecation.

* Add authors, add edition, point openvr-sys at my temporary branch that ports to v2.5.1. Ignore .cargo in root.

* Run cargo fix.

* Fix some warnings from using mem::uninitialized instead of MaybeUninit<T>.

* Fix remaining warnings from using mem::uninitialized instead of MaybeUninit<T>.

* Fix remaining warnings for using deprecated description method with Errors, fix unused import warning.

* Run tests on all branches.

* No fail fast.

* Work arounds for E0308, E0793 happening on linux/mac.

* Can use master branch of my repo now.

* Matrix build/test strategy as in in the sys crate. Use the official repository rather than my branch.

* Bump version.

* Use sys crate from crates.io.
